### PR TITLE
fix(release-notes): stop sending the log message in sonia guild if nothing was sent

### DIFF
--- a/src/features/firebase/services/guilds/firebase-guilds-new-version-count.service.spec.ts
+++ b/src/features/firebase/services/guilds/firebase-guilds-new-version-count.service.spec.ts
@@ -102,6 +102,22 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           message: `text-no release note message sent`,
         } as ILoggerLog);
       });
+
+      it(`should not get a message response about the count`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).not.toHaveBeenCalled();
+      });
+
+      it(`should not send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).not.toHaveBeenCalled();
+      });
     });
 
     describe(`when the given guild messages is an empty array`, (): void => {
@@ -119,6 +135,22 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           context: `FirebaseGuildsNewVersionCountService`,
           message: `text-no release note message sent`,
         } as ILoggerLog);
+      });
+
+      it(`should not get a message response about the count`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).not.toHaveBeenCalled();
+      });
+
+      it(`should not send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -138,6 +170,22 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           message: `text-no release note message sent for the value-1 guild`,
         } as ILoggerLog);
       });
+
+      it(`should not get a message response about the count`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).not.toHaveBeenCalled();
+      });
+
+      it(`should not send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).not.toHaveBeenCalled();
+      });
     });
 
     describe(`when the given guild messages is an array with two undefined values`, (): void => {
@@ -155,6 +203,22 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           context: `FirebaseGuildsNewVersionCountService`,
           message: `text-no release note message sent for the value-2 guilds`,
         } as ILoggerLog);
+      });
+
+      it(`should not get a message response about the count`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).not.toHaveBeenCalled();
+      });
+
+      it(`should not send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -174,6 +238,22 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           message: `text-no release note message sent for the value-1 guild`,
         } as ILoggerLog);
       });
+
+      it(`should not get a message response about the count`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).not.toHaveBeenCalled();
+      });
+
+      it(`should not send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).not.toHaveBeenCalled();
+      });
     });
 
     describe(`when the given guild messages is an array with two empty arrays`, (): void => {
@@ -191,6 +271,22 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           context: `FirebaseGuildsNewVersionCountService`,
           message: `text-no release note message sent for the value-2 guilds`,
         } as ILoggerLog);
+      });
+
+      it(`should not get a message response about the count`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).not.toHaveBeenCalled();
+      });
+
+      it(`should not send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -210,6 +306,22 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           message: `text-no release note message sent for the value-1 guild`,
         } as ILoggerLog);
       });
+
+      it(`should not get a message response about the count`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).not.toHaveBeenCalled();
+      });
+
+      it(`should not send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).not.toHaveBeenCalled();
+      });
     });
 
     describe(`when the given guild messages is an array with two arrays of one undefined value`, (): void => {
@@ -227,6 +339,22 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           context: `FirebaseGuildsNewVersionCountService`,
           message: `text-no release note message sent for the value-2 guilds`,
         } as ILoggerLog);
+      });
+
+      it(`should not get a message response about the count`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).not.toHaveBeenCalled();
+      });
+
+      it(`should not send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(1);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -246,6 +374,27 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           message: `text-value-1 release note message sent over value-1 guild of value-1`,
         } as ILoggerLog);
       });
+
+      it(`should get a message response about the count`, (): void => {
+        expect.assertions(2);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).toHaveBeenCalledTimes(1);
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).toHaveBeenCalledWith(1, 1, 1);
+      });
+
+      it(`should send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(2);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).toHaveBeenCalledTimes(1);
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).toHaveBeenCalledWith({
+          channelName: `logs`,
+          messageResponse: discordMessageResponse,
+        } as IDiscordGuildSoniaSendMessageToChannel);
+      });
     });
 
     describe(`when the given guild messages is an array with two arrays of one message`, (): void => {
@@ -263,6 +412,27 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           context: `FirebaseGuildsNewVersionCountService`,
           message: `text-value-2 release note messages sent over value-2 guilds of value-2`,
         } as ILoggerLog);
+      });
+
+      it(`should get a message response about the count`, (): void => {
+        expect.assertions(2);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).toHaveBeenCalledTimes(1);
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).toHaveBeenCalledWith(2, 2, 2);
+      });
+
+      it(`should send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(2);
+
+        service.countChannelsAndGuilds(guildMessages);
+
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).toHaveBeenCalledTimes(1);
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).toHaveBeenCalledWith({
+          channelName: `logs`,
+          messageResponse: discordMessageResponse,
+        } as IDiscordGuildSoniaSendMessageToChannel);
       });
     });
 
@@ -289,43 +459,27 @@ describe(`FirebaseGuildsNewVersionCountService`, (): void => {
           message: `text-value-4 release note messages sent over value-3 guilds of value-6`,
         } as ILoggerLog);
       });
-    });
 
-    it(`should get a message response about the count`, (): void => {
-      expect.assertions(2);
-      guildMessages = [
-        [],
-        [null],
-        [createMock<Message>()],
-        [null, null],
-        [createMock<Message>(), null],
-        [createMock<Message>(), createMock<Message>()],
-      ];
+      it(`should get a message response about the count`, (): void => {
+        expect.assertions(2);
 
-      service.countChannelsAndGuilds(guildMessages);
+        service.countChannelsAndGuilds(guildMessages);
 
-      expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).toHaveBeenCalledTimes(1);
-      expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).toHaveBeenCalledWith(6, 3, 4);
-    });
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).toHaveBeenCalledTimes(1);
+        expect(firebaseGuildsNewVersionCountMessageResponseServiceGetMessageResponseSpy).toHaveBeenCalledWith(6, 3, 4);
+      });
 
-    it(`should send the message response about the count into the Sonia logs channel`, (): void => {
-      expect.assertions(2);
-      guildMessages = [
-        [],
-        [null],
-        [createMock<Message>()],
-        [null, null],
-        [createMock<Message>(), null],
-        [createMock<Message>(), createMock<Message>()],
-      ];
+      it(`should send the message response about the count into the Sonia logs channel`, (): void => {
+        expect.assertions(2);
 
-      service.countChannelsAndGuilds(guildMessages);
+        service.countChannelsAndGuilds(guildMessages);
 
-      expect(discordGuildSoniaServiceSendMessageToChannelSpy).toHaveBeenCalledTimes(1);
-      expect(discordGuildSoniaServiceSendMessageToChannelSpy).toHaveBeenCalledWith({
-        channelName: `logs`,
-        messageResponse: discordMessageResponse,
-      } as IDiscordGuildSoniaSendMessageToChannel);
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).toHaveBeenCalledTimes(1);
+        expect(discordGuildSoniaServiceSendMessageToChannelSpy).toHaveBeenCalledWith({
+          channelName: `logs`,
+          messageResponse: discordMessageResponse,
+        } as IDiscordGuildSoniaSendMessageToChannel);
+      });
     });
   });
 });

--- a/src/features/firebase/services/guilds/firebase-guilds-new-version-count.service.ts
+++ b/src/features/firebase/services/guilds/firebase-guilds-new-version-count.service.ts
@@ -13,6 +13,7 @@ const DEFAULT_GUILD_COUNT = 0;
 const ONE_GUILD = 1;
 const DEFAULT_CHANNEL_COUNT = 0;
 const ONE_CHANNEL = 1;
+const NO_CHANNEL = 0;
 
 export class FirebaseGuildsNewVersionCountService extends AbstractService {
   private static _instance: FirebaseGuildsNewVersionCountService;
@@ -68,14 +69,16 @@ export class FirebaseGuildsNewVersionCountService extends AbstractService {
 
     this._logGuildAndChannelCount(totalGuildCount, guildCount, channelCount);
 
-    DiscordGuildSoniaService.getInstance().sendMessageToChannel({
-      channelName: DiscordGuildSoniaChannelNameEnum.LOGS,
-      messageResponse: FirebaseGuildsNewVersionCountMessageResponseService.getInstance().getMessageResponse(
-        totalGuildCount,
-        guildCount,
-        channelCount
-      ),
-    });
+    if (_.gt(channelCount, NO_CHANNEL)) {
+      DiscordGuildSoniaService.getInstance().sendMessageToChannel({
+        channelName: DiscordGuildSoniaChannelNameEnum.LOGS,
+        messageResponse: FirebaseGuildsNewVersionCountMessageResponseService.getInstance().getMessageResponse(
+          totalGuildCount,
+          guildCount,
+          channelCount
+        ),
+      });
+    }
   }
 
   private _logGuildAndChannelCount(


### PR DESCRIPTION
since the release notes are trigger on start, if sonia reboots the release notes will run and will send a message in sonia guild into logs channel to say that no release notes message was sent.
it's useless since this will never happen

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/Sonia-corporation/sonia-discord/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added/updated (for bugfix/feature)
- [ ] Docs have been added/updated (for bugfix/feature)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Feature (a new feature)
- [x] Bugfix (a bug fix)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] Perf (a code change that improves performance)
- [x] Test (adding missing tests or correcting existing tests)
- [ ] Build (changes that affect the build system, CI configuration or external dependencies)
- [ ] Docs (changes that affect the documentation)
- [ ] Chore (anything else), please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Closes #1389