### PR TITLE
build(automerge): fix bad path name to save the output

### DIFF
--- a/.github/workflows/merge-develop-into-master.yml
+++ b/.github/workflows/merge-develop-into-master.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check if the push contains the label "merge-into-master"
     runs-on: ubuntu-latest
     outputs:
-      HAS_LABEL: ${{ steps.check_labels.outputs.HAS_LABEL }}
+      HAS_LABEL: ${{ steps.save-has-label.outputs.HAS_LABEL }}
     steps:
       - name: Check labels
         id: check_labels
@@ -17,6 +17,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: '["merge-into-master"]'
       - name: Save has label result
+        id: save-has-label
         run: echo '::set-output name=HAS_LABEL::${{ steps.check_labels.outputs.result }}'
       - name: Label present
         if: steps.check_labels.outputs.result == 'true'


### PR DESCRIPTION
the output for the second job was missing so the label to create a PR to merge develop into master was not working

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/Sonia-corporation/sonia-discord/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added/updated (for bugfix/feature)
- [ ] Docs have been added/updated (for bugfix/feature)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Feature (a new feature)
- [ ] Bugfix (a bug fix)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] Perf (a code change that improves performance)
- [ ] Test (adding missing tests or correcting existing tests)
- [x] Build (changes that affect the build system, CI configuration or external dependencies)
- [ ] Docs (changes that affect the documentation)
- [ ] Chore (anything else), please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
