### PR TITLE
feat(help): add more help when encountering the empty feature name

### DIFF
--- a/src/features/discord/messages/services/command/feature/services/feature-names/discord-message-command-feature-empty-feature-name-error.service.spec.ts
+++ b/src/features/discord/messages/services/command/feature/services/feature-names/discord-message-command-feature-empty-feature-name-error.service.spec.ts
@@ -134,12 +134,12 @@ describe(`DiscordMessageCommandFeatureEmptyFeatureNameErrorService`, (): void =>
       expect(result.options.embed?.color).toStrictEqual(ColorEnum.CANDY);
     });
 
-    it(`should return a Discord message response embed with 3 fields`, async (): Promise<void> => {
+    it(`should return a Discord message response embed with 4 fields`, async (): Promise<void> => {
       expect.assertions(1);
 
       const result = await service.getMessageResponse(anyDiscordMessage, commands);
 
-      expect(result.options.embed?.fields).toHaveLength(3);
+      expect(result.options.embed?.fields).toHaveLength(4);
     });
 
     it(`should return a Discord message response embed with a field explaining the error`, async (): Promise<void> => {
@@ -180,6 +180,18 @@ describe(`DiscordMessageCommandFeatureEmptyFeatureNameErrorService`, (): void =>
           value: `\`!feature noon\``,
         } as EmbedFieldData);
       });
+
+      it(`should return a Discord message response embed with a field to show an example of the command with the help flag and the "!feature" command`, async (): Promise<void> => {
+        expect.assertions(1);
+        discordMessageConfigServiceGetMessageCommandPrefixSpy.mockReturnValue([`-`]);
+
+        const result = await service.getMessageResponse(anyDiscordMessage, commands);
+
+        expect(result.options.embed?.fields?.[3]).toStrictEqual({
+          name: `Need help?`,
+          value: `If you need my help, you can also specify the help flag \`!feature --help\` and I will try my best to help you!`,
+        } as EmbedFieldData);
+      });
     });
 
     describe(`when the given Discord message content is not a valid command`, (): void => {
@@ -196,6 +208,18 @@ describe(`DiscordMessageCommandFeatureEmptyFeatureNameErrorService`, (): void =>
         expect(result.options.embed?.fields?.[2]).toStrictEqual({
           name: `Example`,
           value: `\`!feature noon\``,
+        } as EmbedFieldData);
+      });
+
+      it(`should return a Discord message response embed with a field to show an example of the command with the help flag and the "!feature" command`, async (): Promise<void> => {
+        expect.assertions(1);
+        discordMessageConfigServiceGetMessageCommandPrefixSpy.mockReturnValue([`-`]);
+
+        const result = await service.getMessageResponse(anyDiscordMessage, commands);
+
+        expect(result.options.embed?.fields?.[3]).toStrictEqual({
+          name: `Need help?`,
+          value: `If you need my help, you can also specify the help flag \`!feature --help\` and I will try my best to help you!`,
         } as EmbedFieldData);
       });
     });
@@ -221,6 +245,17 @@ describe(`DiscordMessageCommandFeatureEmptyFeatureNameErrorService`, (): void =>
             value: `\`!f noon\``,
           } as EmbedFieldData);
         });
+
+        it(`should return a Discord message response embed with a field to show an example of the command with the help flag by taking the prefix and command`, async (): Promise<void> => {
+          expect.assertions(1);
+
+          const result = await service.getMessageResponse(anyDiscordMessage, commands);
+
+          expect(result.options.embed?.fields?.[3]).toStrictEqual({
+            name: `Need help?`,
+            value: `If you need my help, you can also specify the help flag \`!f --help\` and I will try my best to help you!`,
+          } as EmbedFieldData);
+        });
       });
 
       describe(`when the prefix is "-"`, (): void => {
@@ -236,6 +271,17 @@ describe(`DiscordMessageCommandFeatureEmptyFeatureNameErrorService`, (): void =>
           expect(result.options.embed?.fields?.[2]).toStrictEqual({
             name: `Example`,
             value: `\`!feature noon\``,
+          } as EmbedFieldData);
+        });
+
+        it(`should return a Discord message response embed with a field to show an example of the command with the help flag and the "!feature" command`, async (): Promise<void> => {
+          expect.assertions(1);
+
+          const result = await service.getMessageResponse(anyDiscordMessage, commands);
+
+          expect(result.options.embed?.fields?.[3]).toStrictEqual({
+            name: `Need help?`,
+            value: `If you need my help, you can also specify the help flag \`!feature --help\` and I will try my best to help you!`,
           } as EmbedFieldData);
         });
       });
@@ -262,6 +308,17 @@ describe(`DiscordMessageCommandFeatureEmptyFeatureNameErrorService`, (): void =>
             value: `\`!feature noon\``,
           } as EmbedFieldData);
         });
+
+        it(`should return a Discord message response embed with a field to show an example of the command with the help flag and the "!feature" command`, async (): Promise<void> => {
+          expect.assertions(1);
+
+          const result = await service.getMessageResponse(anyDiscordMessage, commands);
+
+          expect(result.options.embed?.fields?.[3]).toStrictEqual({
+            name: `Need help?`,
+            value: `If you need my help, you can also specify the help flag \`!feature --help\` and I will try my best to help you!`,
+          } as EmbedFieldData);
+        });
       });
 
       describe(`when the prefix is "-"`, (): void => {
@@ -277,6 +334,17 @@ describe(`DiscordMessageCommandFeatureEmptyFeatureNameErrorService`, (): void =>
           expect(result.options.embed?.fields?.[2]).toStrictEqual({
             name: `Example`,
             value: `\`-lunch noon\``,
+          } as EmbedFieldData);
+        });
+
+        it(`should return a Discord message response embed with a field to show an example of the command with the help flag by taking the prefix and command`, async (): Promise<void> => {
+          expect.assertions(1);
+
+          const result = await service.getMessageResponse(anyDiscordMessage, commands);
+
+          expect(result.options.embed?.fields?.[3]).toStrictEqual({
+            name: `Need help?`,
+            value: `If you need my help, you can also specify the help flag \`-lunch --help\` and I will try my best to help you!`,
           } as EmbedFieldData);
         });
       });

--- a/src/features/discord/messages/services/command/feature/services/feature-names/discord-message-command-feature-empty-feature-name-error.service.ts
+++ b/src/features/discord/messages/services/command/feature/services/feature-names/discord-message-command-feature-empty-feature-name-error.service.ts
@@ -1,7 +1,9 @@
 import { ServiceNameEnum } from '../../../../../../../../enums/service-name.enum';
 import { DiscordMessageCommandEnum } from '../../../../../enums/commands/discord-message-command.enum';
+import { discordGetCommandAndPrefix } from '../../../../../functions/commands/getters/discord-get-command-and-prefix';
 import { IDiscordMessageResponse } from '../../../../../interfaces/discord-message-response';
 import { IAnyDiscordMessage } from '../../../../../types/any-discord-message';
+import { DiscordMessageConfigService } from '../../../../config/discord-message-config.service';
 import { DiscordMessageCommandCliErrorService } from '../../../discord-message-command-cli-error.service';
 import { DiscordMessageCommandFeatureErrorCoreService } from '../discord-message-command-feature-error-core.service';
 import { EmbedFieldData, MessageEmbedOptions } from 'discord.js';
@@ -61,6 +63,7 @@ export class DiscordMessageCommandFeatureEmptyFeatureNameErrorService extends Di
       this._getMessageEmbedFieldError(),
       this._getMessageEmbedFieldAllFeatures(),
       this._getMessageEmbedFieldFeatureExample(anyDiscordMessage, commands),
+      this._getMessageEmbedFieldNeedHelp(anyDiscordMessage, commands),
     ];
   }
 
@@ -68,6 +71,26 @@ export class DiscordMessageCommandFeatureEmptyFeatureNameErrorService extends Di
     return {
       name: `Empty feature name`,
       value: `You did not specify the name of the feature you wish to configure.\nI will not guess it for you so please try again with a feature name!\nAnd because I am kind and generous here is the list of all the features you can configure with an example.`,
+    };
+  }
+
+  private _getMessageEmbedFieldNeedHelp(
+    { content }: Readonly<IAnyDiscordMessage>,
+    commands: Readonly<DiscordMessageCommandEnum>[]
+  ): EmbedFieldData {
+    let userCommand: string | null = discordGetCommandAndPrefix({
+      commands,
+      message: _.isNil(content) ? `` : content,
+      prefixes: DiscordMessageConfigService.getInstance().getMessageCommandPrefix(),
+    });
+
+    if (_.isNil(userCommand)) {
+      userCommand = `!${_.toLower(DiscordMessageCommandEnum.FEATURE)}`;
+    }
+
+    return {
+      name: `Need help?`,
+      value: `If you need my help, you can also specify the help flag \`${userCommand} --help\` and I will try my best to help you!`,
     };
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfils the following requirements:

- [ ] The commit message follows our [guidelines](https://github.com/Sonia-corporation/sonia-discord/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added/updated (for bugfix/feature)
- [ ] Docs have been added/updated (for bugfix/feature)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Feature (a new feature)
- [ ] Bugfix (a bug fix)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] Perf (a code change that improves performance)
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Build (changes that affect the build system, CI configuration or external dependencies)
- [ ] Docs (changes that affect the documentation)
- [ ] Chore (anything else), please describe:

## What is the new behaviour?

- [x] Include a new field when showing the "Empty feature name" to help users to use the --help flag

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Closes #735 